### PR TITLE
#1 Error is now packed into Error Object

### DIFF
--- a/src/TakaakiMizuno/FacebookObject/Objects/Error.php
+++ b/src/TakaakiMizuno/FacebookObject/Objects/Error.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TakaakiMizuno\FacebookObject\Objects;
+
+class Error extends BaseObject
+{
+
+    protected $_fields = [
+        'message',
+        'type',
+        'code'
+    ];
+
+}

--- a/src/TakaakiMizuno/FacebookObject/Repositories/BaseRepository.php
+++ b/src/TakaakiMizuno/FacebookObject/Repositories/BaseRepository.php
@@ -4,6 +4,7 @@ namespace TakaakiMizuno\FacebookObject\Repositories;
 
 use Facebook\FacebookRequest;
 use Facebook\FacebookSession;
+use Facebook\FacebookRequestException;
 
 class BaseRepository
 {
@@ -18,6 +19,34 @@ class BaseRepository
         $this->_session = $session;
     }
 
+    /**
+     * @param \Facebook\GraphObject $object
+     * @return \TakaakiMizuno\FacebookObject\Objects\Error|null
+     */
+    private function checkError($object)
+    {
+        return ( $object instanceof \TakaakiMizuno\FacebookObject\Objects\Error ) ? true : false;
+    }
+
+    /**
+     * @param string $path
+     * @param string $method
+     * @param array $params
+     * @return \Facebook\GraphObject|null
+     */
+    private function _access($method, $path, $params)
+    {
+        try {
+            $result = (new FacebookRequest(
+                $this->_session, $method, $path, $params
+            ))->execute()->getGraphObject();
+            return $result;
+        }catch (FacebookRequestException $e){
+            $error = $e->getResponse();
+            return new \TakaakiMizuno\FacebookObject\Objects\Error($error['error'], $this->_session);
+        }
+    }
+
     protected function _all($path)
     {
         $limit = 25;
@@ -26,6 +55,9 @@ class BaseRepository
         $hasNext = true;
         while ($hasNext) {
             $result = $this->_get($path, $limit, $offset);
+            if( $this->checkError($result) ){
+                return $result;
+            }
             $list += $result->getProperty('data')->asArray();
             $paging = $result->getProperty('paging');
             if (null !== $paging && null != $paging->getProperty('next')) {
@@ -39,25 +71,26 @@ class BaseRepository
 
     protected function _get($path, $limit = 1000, $offset = 0)
     {
-        $result = (new FacebookRequest(
-            $this->_session, 'GET', $path, [
+        $result = $this->_access('GET', $path,
+            [
                 'limit'  => $limit,
                 'offset' => $offset,
             ]
-        ))->execute()->getGraphObject();
+        );
         return $result;
     }
 
     protected function _find($path)
     {
-        $object = (new FacebookRequest(
-            $this->_session, 'GET', $path
-        ))->execute()->getGraphObject();
-        return $object;
+        $result = $this->_access('GET', $path, []);
+        return $result;
     }
 
     public function allWithClass($path, $class){
         $list = $this->_all($path);
+        if( $this->checkError($list) ){
+            return $list;
+        }
         $result = [];
         foreach( $list as $item ){
             $result[] = new $class(json_decode(json_encode($item), true), $this->_session);
@@ -68,6 +101,9 @@ class BaseRepository
     public function getWithClass($path, $class, $limit = 1000, $offset = 0)
     {
         $list = $this->_get($path, $limit, $offset);
+        if( $this->checkError($list) ){
+            return $list;
+        }
         $result = [];
         foreach( $list as $item ){
             $result[] = new $class($item->asArray(), $this->_session);
@@ -78,6 +114,9 @@ class BaseRepository
     public function findWithClass($path, $class)
     {
         $item = $this->_find($path);
+        if( $this->checkError($item) ){
+            return $item;
+        }
         return new $class($item->asArray(), $this->_session);
     }
 

--- a/tests/TakaakiMizuno/FacebookObject/testError.php
+++ b/tests/TakaakiMizuno/FacebookObject/testError.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TakaakiMizuno\FacebookObject\tests;
+
+class testError extends testBase
+{
+    public function testGetError()
+    {
+
+        $session = $this->getSession();
+        $repository = new \TakaakiMizuno\FacebookObject\Repositories\UserRepository($session);
+
+        $error = $repository->find(4321);
+
+        $this->assertInstanceOf('\TakaakiMizuno\FacebookObject\Objects\Error', $error, 'non exist user id request');
+    }
+}

--- a/tests/TakaakiMizuno/FacebookObject/testMe.php
+++ b/tests/TakaakiMizuno/FacebookObject/testMe.php
@@ -25,6 +25,8 @@ class testMe extends testBase
         $adaccounts = $me->adaccounts;
         $this->assertTrue(is_array($adaccounts));
 
+        $adaccounts = $user->adaccounts;
+        $this->assertTrue(is_array($adaccounts));
 
     }
 }


### PR DESCRIPTION
Catch Facebook SDK's Exceptions in this module and returns ErrorObject instead of Exceptions
